### PR TITLE
Added support for postfix smtpd_smtp_proxy aka pre-queue filter 

### DIFF
--- a/mailgraph.pl
+++ b/mailgraph.pl
@@ -251,12 +251,17 @@ sub process_line($)
 			}
 		}
 		elsif($prog eq 'smtpd') {
-			if($text =~ /^[0-9A-Z]+: client=(\S+)/) {
-				my $client = $1;
+			if($text =~ /^([0-9A-Z]+): client=([^, ]+)/) {
+				my $type = $1;
+				my $client = $2;
+				return if $type eq 'NOQUEUE';
 				return if $opt{'ignore-localhost'} and
 					$client =~ /\[127\.0\.0\.1\]$/;
 				return if $opt{'ignore-host'} and
 					$client =~ /$opt{'ignore-host'}/oi;
+				event($time, 'received');
+			}
+			elsif ($text =~ /^proxy-accept/) {
 				event($time, 'received');
 			}
 			elsif($opt{'virbl-is-virus'} and $text =~ /^(?:[0-9A-Z]+: |NOQUEUE: )?reject: .*: 554.* blocked using virbl.dnsbl.bit.nl/) {
@@ -265,7 +270,7 @@ sub process_line($)
 			elsif($opt{'rbl-is-spam'} and $text    =~ /^(?:[0-9A-Z]+: |NOQUEUE: )?reject: .*: 554.* blocked using/) {
 				event($time, 'spam');
 			}
-			elsif($text =~ /^(?:[0-9A-Z]+: |NOQUEUE: )?reject: /) {
+			elsif($text =~ /^(?:[0-9A-Z]+: |NOQUEUE: |proxy-)?reject: /) {
 				event($time, 'rejected');
 			}
 			elsif($text =~ /^(?:[0-9A-Z]+: |NOQUEUE: )?milter-reject: /) {


### PR DESCRIPTION
Without this fix all "back-"connects of the smtp_proxy are counted as received and also NOQUEUE-lines which signals that the proxy will be asked are also counted as received.
