### PR TITLE
adding patch from kernel-error.de for SPF, DMARC and DKIM graphs

### DIFF
--- a/mailgraph.cgi
+++ b/mailgraph.cgi
@@ -4,6 +4,7 @@
 # copyright (c) 2000-2007 ETH Zurich
 # copyright (c) 2000-2007 David Schweikert <david@schweikert.ch>
 # released under the GNU General Public License
+# with dkim-, dmarc, spf-patch Sebastian van de Meer <kernel-error@kernel-error.de>
 
 use RRDs;
 use POSIX qw(uname);
@@ -15,7 +16,10 @@ my $scriptname = 'mailgraph.cgi';
 my $xpoints = 540;
 my $points_per_sample = 3;
 my $ypoints = 160;
+my $ypoints_spf = 96;
+my $ypoints_dmarc = 96;
 my $ypoints_err = 96;
+my $ypoints_dkim = 96;
 my $rrd = 'mailgraph.rrd'; # path to where the RRD database is
 my $rrd_virus = 'mailgraph_virus.rrd'; # path to where the Virus RRD database is
 my $tmp_dir = '/tmp/mailgraph'; # temporary directory where to store the images
@@ -32,7 +36,16 @@ my @graphs = (
 my %color = (
 	sent     => '000099', # rrggbb in hex
 	received => '009900',
-	rejected => 'AA0000', 
+	rejected => 'AA0000',
+	spfnone    => '000AAA',
+	spffail    => '12FF0A',
+	spfpass    => 'D15400',
+	dmarcnone  => 'FFFF00',
+	dmarcfail  => 'FF00EA',
+	dmarcpass  => '00FFD5',
+	dkimnone   => '3013EC',
+	dkimfail   => '006B3A',
+	dkimpass   => '491503', 
 	bounced  => '000000',
 	virus    => 'DDBB00',
 	spam     => '999999',
@@ -153,6 +166,126 @@ sub graph_err($$)
 	);
 }
 
+sub graph_spf($$)
+{
+	my ($range, $file) = @_;
+	my $step = $range*$points_per_sample/$xpoints;
+	rrd_graph($range, $file, $ypoints_spf,
+		"DEF:spfpass=$rrd:spfpass:AVERAGE",
+		"DEF:mspfpass=$rrd:spfpass:MAX",
+		"CDEF:rspfpass=spfpass,60,*",
+		"CDEF:dspfpass=spfpass,UN,0,spfpass,IF,$step,*",
+		"CDEF:sspfpass=PREV,UN,dspfpass,PREV,IF,dspfpass,+",
+		"CDEF:rmspfpass=mspfpass,60,*",
+		"AREA:rspfpass#$color{spfpass}:SPF pass",
+		'GPRINT:sspfpass:MAX:total\: %8.0lf msgs',
+		'GPRINT:rspfpass:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmspfpass:MAX:max\: %4.0lf msgs/min\l',
+	
+		"DEF:spfnone=$rrd:spfnone:AVERAGE",
+		"DEF:mspfnone=$rrd:spfnone:MAX",
+		"CDEF:rspfnone=spfnone,60,*",
+		"CDEF:dspfnone=spfnone,UN,0,spfnone,IF,$step,*",
+		"CDEF:sspfnone=PREV,UN,dspfnone,PREV,IF,dspfnone,+",
+		"CDEF:rmspfnone=mspfnone,60,*",
+		"STACK:rspfnone#$color{spfnone}:SPF none",
+		'GPRINT:sspfnone:MAX:total\: %8.0lf msgs',
+		'GPRINT:rspfnone:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmspfnone:MAX:max\: %4.0lf msgs/min\l',
+
+		"DEF:spffail=$rrd:spffail:AVERAGE",
+		"DEF:mspffail=$rrd:spffail:MAX",
+		"CDEF:rspffail=spffail,60,*",
+		"CDEF:dspffail=spffail,UN,0,spffail,IF,$step,*",
+		"CDEF:sspffail=PREV,UN,dspffail,PREV,IF,dspffail,+",
+		"CDEF:rmspffail=mspffail,60,*",
+		"LINE2:rspffail#$color{spffail}:SPF fail",
+		'GPRINT:sspffail:MAX:total\: %8.0lf msgs',
+		'GPRINT:rspffail:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmspffail:MAX:max\: %4.0lf msgs/min\l',
+	);
+}
+
+sub graph_dmarc($$)
+{
+	my ($range, $file) = @_;
+	my $step = $range*$points_per_sample/$xpoints;
+	rrd_graph($range, $file, $ypoints_dmarc,
+		"DEF:dmarcpass=$rrd:dmarcpass:AVERAGE",
+		"DEF:mdmarcpass=$rrd:dmarcpass:MAX",
+		"CDEF:rdmarcpass=dmarcpass,60,*",
+		"CDEF:ddmarcpass=dmarcpass,UN,0,dmarcpass,IF,$step,*",
+		"CDEF:sdmarcpass=PREV,UN,ddmarcpass,PREV,IF,ddmarcpass,+",
+		"CDEF:rmdmarcpass=mdmarcpass,60,*",
+		"AREA:rdmarcpass#$color{dmarcpass}:DMARC pass",
+		'GPRINT:sdmarcpass:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdmarcpass:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdmarcpass:MAX:max\: %4.0lf msgs/min\l',
+		
+		"DEF:dmarcnone=$rrd:dmarcnone:AVERAGE",
+		"DEF:mdmarcnone=$rrd:dmarcnone:MAX",
+		"CDEF:rdmarcnone=dmarcnone,60,*",
+		"CDEF:ddmarcnone=dmarcnone,UN,0,dmarcnone,IF,$step,*",
+		"CDEF:sdmarcnone=PREV,UN,ddmarcnone,PREV,IF,ddmarcnone,+",
+		"CDEF:rmdmarcnone=mdmarcnone,60,*",
+		"STACK:rdmarcnone#$color{dmarcnone}:DMARC none",
+		'GPRINT:sdmarcnone:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdmarcnone:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdmarcnone:MAX:max\: %4.0lf msgs/min\l',
+
+		"DEF:dmarcfail=$rrd:dmarcfail:AVERAGE",
+		"DEF:mdmarcfail=$rrd:dmarcfail:MAX",
+		"CDEF:rdmarcfail=dmarcfail,60,*",
+		"CDEF:ddmarcfail=dmarcfail,UN,0,dmarcfail,IF,$step,*",
+		"CDEF:sdmarcfail=PREV,UN,ddmarcfail,PREV,IF,ddmarcfail,+",
+		"CDEF:rmdmarcfail=mdmarcfail,60,*",
+		"LINE2:rdmarcfail#$color{dmarcfail}:DMARC fail",
+		'GPRINT:sdmarcfail:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdmarcfail:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdmarcfail:MAX:max\: %4.0lf msgs/min\l',
+	);
+}
+
+sub graph_dkim($$)
+{
+	my ($range, $file) = @_;
+	my $step = $range*$points_per_sample/$xpoints;
+	rrd_graph($range, $file, $ypoints_dkim,
+		"DEF:dkimpass=$rrd:dkimpass:AVERAGE",
+		"DEF:mdkimpass=$rrd:dkimpass:MAX",
+		"CDEF:rdkimpass=dkimpass,60,*",
+		"CDEF:ddkimpass=dkimpass,UN,0,dkimpass,IF,$step,*",
+		"CDEF:sdkimpass=PREV,UN,ddkimpass,PREV,IF,ddkimpass,+",
+		"CDEF:rmdkimpass=mdkimpass,60,*",
+		"AREA:rdkimpass#$color{dkimpass}:DKIM pass",
+		'GPRINT:sdkimpass:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdkimpass:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdkimpass:MAX:max\: %4.0lf msgs/min\l',
+		
+		"DEF:dkimnone=$rrd:dkimnone:AVERAGE",
+		"DEF:mdkimnone=$rrd:dkimnone:MAX",
+		"CDEF:rdkimnone=dkimnone,60,*",
+		"CDEF:ddkimnone=dkimnone,UN,0,dkimnone,IF,$step,*",
+		"CDEF:sdkimnone=PREV,UN,ddkimnone,PREV,IF,ddkimnone,+",
+		"CDEF:rmdkimnone=mdkimnone,60,*",
+		"STACK:rdkimnone#$color{dkimnone}:DKIM none",
+		'GPRINT:sdkimnone:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdkimnone:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdkimnone:MAX:max\: %4.0lf msgs/min\l',
+
+		"DEF:dkimfail=$rrd:dkimfail:AVERAGE",
+		"DEF:mdkimfail=$rrd:dkimfail:MAX",
+		"CDEF:rdkimfail=dkimfail,60,*",
+		"CDEF:ddkimfail=dkimfail,UN,0,dkimfail,IF,$step,*",
+		"CDEF:sdkimfail=PREV,UN,ddkimfail,PREV,IF,ddkimfail,+",
+		"CDEF:rmdkimfail=mdkimfail,60,*",
+		"LINE2:rdkimfail#$color{dkimfail}:DKIM fail",
+		'GPRINT:sdkimfail:MAX:total\: %8.0lf msgs',
+		'GPRINT:rdkimfail:AVERAGE:avg\: %5.2lf msgs/min',
+		'GPRINT:rmdkimfail:MAX:max\: %4.0lf msgs/min\l',
+	);
+}
+
 sub print_html()
 {
 	print "Content-Type: text/html\n\n";
@@ -182,6 +315,9 @@ HEADER
 		print "<h2 id=\"G$n\">$graphs[$n]{title}</h2>\n";
 		print "<p><img src=\"$scriptname?${n}-n\" alt=\"mailgraph\"/><br/>\n";
 		print "<img src=\"$scriptname?${n}-e\" alt=\"mailgraph\"/></p>\n";
+		print "<img src=\"$scriptname?${n}-s\" alt=\"mailgraph\"/></p>\n";
+		print "<img src=\"$scriptname?${n}-d\" alt=\"mailgraph\"/></p>\n";
+		print "<img src=\"$scriptname?${n}-k\" alt=\"mailgraph\"/></p>\n";
 	}
 
 	print <<FOOTER;
@@ -232,6 +368,21 @@ sub main()
 		elsif($img =~ /^(\d+)-e$/) {
 			my $file = "$tmp_dir/$uri/mailgraph_$1_err.png";
 			graph_err($graphs[$1]{seconds}, $file);
+			send_image($file);
+		}
+		elsif($img =~ /^(\d+)-s$/) {
+			my $file = "$tmp_dir/$uri/mailgraph_$1_spf.png";
+			graph_spf($graphs[$1]{seconds}, $file);
+			send_image($file);
+		}
+		elsif($img =~ /^(\d+)-d$/) {
+			my $file = "$tmp_dir/$uri/mailgraph_$1_dmarc.png";
+			graph_dmarc($graphs[$1]{seconds}, $file);
+			send_image($file);
+		}
+		elsif($img =~ /^(\d+)-k$/) {
+			my $file = "$tmp_dir/$uri/mailgraph_$1_dkim.png";
+			graph_dkim($graphs[$1]{seconds}, $file);
 			send_image($file);
 		}
 		else {


### PR DESCRIPTION
Hi David, 

i search for dkim graphs for opengraph and found this german blog post. https://www.kernel-error.de/postfix/mailgraph-aufgebohrt

Maybe you are interested to merge this in your code for future releases. i havn't tested it but in the next days i will do it on my mailserver. 

Regards
