### PR TITLE
Added milter reject to cleanup section

### DIFF
--- a/mailgraph.pl
+++ b/mailgraph.pl
@@ -287,6 +287,24 @@ sub process_line($)
 			if($text =~ /^[0-9A-Za-z]+: (?:reject|discard): /) {
 				event($time, 'rejected');
 			}
+			## Added sbidy
+			elsif($text =~ /^(?:[0-9A-Za-z]+: |NOQUEUE: )?milter-reject: /) {
+				if($text =~ /Blocked by SpamAssassin/) {
+					event($time, 'spam');
+				}
+				else {
+					event($time, 'rejected');
+				}
+			}
+			## In version 1.14
+			##elsif($text =~ /^(?:[\dA-F]+: |[\dB-DF-HJ-NP-TV-Zb-df-hj-np-tv-z]+: |NOQUEUE: )?milter-reject: /) {
+                        ##        if($text =~ /Blocked by SpamAssassin/) {
+                        ##                event($time, 'spam');
+                        ##        } 
+                        ##        else {
+                        ##                event($time, 'rejected');
+                        ##        }
+                        ##}
 		}
 		elsif($prog eq 'postscreen') {
 			if($text =~ /NOQUEUE: reject: RCPT from .* /) {


### PR DESCRIPTION
The the cleanup section don't recognized the "milter-reject" case as "reject" in 1.14 and 1.11. Added the elseif from the smtpd section.

Test:
$sl= Jan 19 14:42:50 SYSTEMNAME postfix/cleanup[3101]:
$proc = cleanup
$text = 40C12F39F: milter-reject: END-OF-MESSAGE from 45.Red-80-39-23.staticIP.rima-tde.net[80.39.23.45]: 5.7.1 Delivery not authorized, message refused!; from=<PierceJeremiah1411@example.com> to=<nonpollutingja@example.com> proto=ESMTP helo=<45.Red-80-39-23.staticIP.rima-tde.net>