### PR TITLE
Fix regular expression for exim logging to syslog.

### DIFF
--- a/mailgraph.pl
+++ b/mailgraph.pl
@@ -117,7 +117,7 @@ sub main
 
 	daemonize if $opt{daemon};
 
-	my $logfile = defined $opt{logfile} ? $opt{logfile} : '/var/log/syslog';
+	$logfile = defined $opt{logfile} ? $opt{logfile} : '/var/log/syslog';
 	my $file;
 	if($opt{cat}) {
 		$file = $logfile;
@@ -372,10 +372,11 @@ sub process_line($)
 		}
 	}
 	elsif($prog eq 'exim') {
-		if($text =~ /^[0-9a-zA-Z]{6}-[0-9a-zA-Z]{6}-[0-9a-zA-Z]{2} <= \S+/) {
+		my $prefix = (index($logfile, 'syslog') == -1) ? '^' : '';
+		if($text =~ /$prefix[0-9a-zA-Z]{6}-[0-9a-zA-Z]{6}-[0-9a-zA-Z]{2} <= \S+/) {
 			event($time, 'received');
 		}
-		elsif($text =~ /^[0-9a-zA-Z]{6}-[0-9a-zA-Z]{6}-[0-9a-zA-Z]{2} => \S+/) {
+		elsif($text =~ /$prefix[0-9a-zA-Z]{6}-[0-9a-zA-Z]{6}-[0-9a-zA-Z]{2} => \S+/) {
 			event($time, 'sent');
 		}
 		elsif($text =~ / rejected because \S+ is in a black list at \S+/) {


### PR DESCRIPTION
When exim writes to syslog the date and time are duplicated; e.g:
```
May 23 10:28:30 mx01 exim[27789]: 2019-05-23 10:28:30 1hTohn-0007EB-Nq Completed
```

I solved this by removing the match on newline; if that's desirable to keep, a regexp instead of the empty prefix would do it.